### PR TITLE
Remove devDependencies from peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,10 +32,7 @@
     "classnames": "~2.2.5"
   },
   "peerDependencies": {
-    "react": "0.14.x || 15.x.x",
-    "chai": "3.x",
-    "cheerio": "0.19.x || 0.20.x",
-    "enzyme": "1.x || 2.x"
+    "react": "0.14.x || 15.x.x"
   },
   "devDependencies": {
     "chai": "3.x",


### PR DESCRIPTION
Having devDependencies specified as peerDependencies places added constraints to anything that uses this (i.e. orderweb).

Trying to run `npm shrinkwrap -dev` in orderweb throws

```bash
client $ npm shrinkwrap -dev
npm ERR! Darwin 15.6.0
npm ERR! argv "/Users/jazlalli/.nvm/versions/node/v5.12.0/bin/node" "/Users/jazlalli/.nvm/versions/node/v5.12.0/bin/npm" "shrinkwrap" "-dev"
npm ERR! node v5.12.0
npm ERR! npm  v3.10.10

npm ERR! Problems were encountered
npm ERR! Please correct and try again.
npm ERR! peer invalid: chai@3.x, required by react-creditCard@0.0.10
npm ERR! peer invalid: cheerio@0.19.x || 0.20.x, required by react-creditCard@0.0.10
npm ERR! peer invalid: enzyme@1.x || 2.x, required by react-creditCard@0.0.10
```

I think they can be removed without issues.
