### PR TITLE
Fixing an issue we're seeing with Samsung phones.  

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-creditCard",
   "description": "Credit Card React component",
-  "version": "0.0.10",
+  "version": "0.0.13",
   "main": "./lib/index.js",
   "jsnext:main": "es6/index.js",
   "standalone": "CreditCard",

--- a/src/index.js
+++ b/src/index.js
@@ -76,14 +76,14 @@ var CreditCard = React.createClass({
 
   safeVal(value, $target) {
     var currPair, cursor, digit, last, prevPair;
+    last = $target.value;
+    $target.value = value;
+    this._onChange(value);
     try {
       cursor = $target.selectionStart;
     } catch (e) {
       cursor = null;
     }
-    last = $target.value;
-    $target.value = value;
-    this._onChange(value);
     if (cursor !== null && $target === document.activeElement) {
       if (cursor === last.length) {
         cursor = value.length;


### PR DESCRIPTION
When typing the numbers would show backwards.  Type 1234 and it would be 4321.  Seems the code below acts differently on Samsung Chrome then normal Chrome.