### PR TITLE
Updated JCB card schema with new length

### DIFF
--- a/src/card-types.js
+++ b/src/card-types.js
@@ -56,7 +56,7 @@ module.exports = [
     type: 'jcb',
     patterns: [35],
     format: defaultFormat,
-    length: [16],
+    length: [16, 17, 18, 19],
     cvcLength: [3],
     luhn: true
   }


### PR DESCRIPTION
[As of February 2017, JCB cards can be 16-19 digits long](https://www.discovernetwork.com/downloads/IPP_VAR_Compliance.pdf). This updates the validation to use the new lengths.